### PR TITLE
Intersect Geometry

### DIFF
--- a/LMIPy/geometry.py
+++ b/LMIPy/geometry.py
@@ -64,7 +64,7 @@ class Geometry:
         try:
             body = json.loads(json.dumps(attributes))
         except:
-            raise ValueError(f"Unable to pass attributes. Expected valid geojson, recieved: {attrributes}")
+            raise ValueError(f"Unable to pass attributes. Expected valid geojson, recieved: {attributes}")
         header= {
                 'Content-Type':'application/json'
                 }
@@ -116,7 +116,7 @@ class Geometry:
 
     def map(self):
         """
-        Returns a folim choropleth map with styles applied via attributes
+        Returns a folium choropleth map with styles applied via attributes
         """
         geojson = self.attributes['geojson']
         geometry = geojson['features'][0]['geometry']


### PR DESCRIPTION
We want to create a `.intersect(<Geometry>)` method for datasets and layers. 

This would act like a Postgres `ST_Intersects` query (if CARTO) or a reduce function for GEE.

- [ ] - Add intersect for carto layers/datasets
- [ ] - Add intersect for json/csv tables
- [ ] - Add intersect for layers (where gfw-api endpoints exist)
- [ ] - Add intersect for GEE assets (using SQL2GEE?)
