### PR TITLE
Add carto query to layers

### DIFF
--- a/LMIPy/dataset.py
+++ b/LMIPy/dataset.py
@@ -257,22 +257,4 @@ class Dataset:
         """."""
         if self.attributes.get('provider') != 'gee':
             raise ValueError("Intersect currently only supported for EE raster data")
-        # geojson = geometry.attributes['geojson']['features'][0]['geometry']
-        # geom_id = geometry.id
-        # table_name = self.attributes.get('tableName', 'data')
-        # sql = f'SELECT * FROM {table_name}'
-
-        # try:
-        #     url = (f'{self.server}/v1/query/{self.id}?sql={sql}&geostore={geom_id}&format=geojson')
-
-        #     r = requests.get(url)
-        #     if r.status_code == 200:
-        #         response_data = r.json().get('data')
-        #         parsed_json = [{**d['properties'], 'geometry': shape(d['geometry'])} for d in response_data[0]['features']]
-        #         df = gpd.GeoDataFrame(parsed_json).set_geometry('geometry')
-        #         return df
-        #     else:
-        #         raise ValueError(f'Unable to get table {self.id} from {r.url}')
-        # except:
-        #     raise ValueError(f'Unable to get table {self.id} from {r.url}')
 

--- a/LMIPy/layer.py
+++ b/LMIPy/layer.py
@@ -1,6 +1,6 @@
 import requests
 #import cartoframes as cf
-#import geopandas as gpd
+import geopandas as gpd
 #import re
 import folium
 import urllib
@@ -335,3 +335,59 @@ class Layer:
         print(f'{self.server}/v1/dataset/{target_dataset_id}/layer/{clone_layer_id}')
         self.attributes = Layer(clone_layer_id).attributes
         return Layer(clone_layer_id)
+
+    def parse_query(self, sql):
+        """
+        Distriibuter to decide interect method
+        """
+        if self.attributes.get('layerConfig') == None:
+            raise ValueError("No layerConfig present in layer from which to create a query.")
+        # if tileLayer
+        if self.attributes.get('provider') == 'leaflet' and self.attributes.get('layerConfig').get('type') == 'tileLayer':
+            print(f"Queries on provider type {self.attributes.get('provider')} currently unavailable.")
+            return None
+        # if GEE
+        if self.attributes.get('provider') == 'gee':
+            print(f"Queries on provider type {self.attributes.get('provider')} currently unavailable.")
+            return None
+        # If CARTO
+        if self.attributes.get('provider') == 'cartodb':
+            return self.get_carto_query(sql)
+        return None
+
+    def get_carto_query(self, sql):
+        """
+        Intersect layer against some geometry class object, geosjon object, shapely shape, or by id.
+        """
+        attributes = self.attributes
+        sql_config = attributes.get('layerConfig').get('sql_config', None)
+        layerConfig = attributes.get('layerConfig')
+        if sql_config:
+            for config in sql_config:
+                key = config['key']
+                key_params = config['key_params']
+                if key_params[0].get('required', False):
+                    for l in layerConfig["body"]["layers"]:
+                        l['options']['sql'] = l['options']['sql'].replace(f'{{{key}}}', '0').format(key_params['key'])
+                else:
+                    for l in layerConfig["body"]["layers"]:
+                        l['options']['sql'] = l['options']['sql'].replace(f'{{{key}}}', '0').format('')
+
+        base_query = f'with t as ({layerConfig["body"]["layers"][0]["options"]["sql"]}) '
+
+        sql = base_query + sql.lower().replace('from data', f'FROM t').replace('"', "'")
+        print(sql)
+        account = layerConfig.get('account')
+        urlCarto = f"https://{account}.carto.com/api/v2/sql"
+        params = {"q": sql}
+        r = requests.get(urlCarto, params=params)
+        if r.status_code == 200:
+            return gpd.GeoDataFrame(r.json().get('rows'))
+        else:
+            raise ValueError(f"Bad response from Carto {r.status_code}: {r.json()}")
+
+    def query(self, sql='SELECT * FROM data LIMIT 5'):
+        """
+        Intersect layer against some geometry class object, geosjon object, shapely shape, or by id.
+        """
+        return self.parse_query(sql=sql)

--- a/LMIPy/layer.py
+++ b/LMIPy/layer.py
@@ -376,7 +376,6 @@ class Layer:
         base_query = f'with t as ({layerConfig["body"]["layers"][0]["options"]["sql"]}) '
 
         sql = base_query + sql.lower().replace('from data', f'FROM t').replace('"', "'")
-        print(sql)
         account = layerConfig.get('account')
         urlCarto = f"https://{account}.carto.com/api/v2/sql"
         params = {"q": sql}
@@ -391,3 +390,10 @@ class Layer:
         Intersect layer against some geometry class object, geosjon object, shapely shape, or by id.
         """
         return self.parse_query(sql=sql)
+
+    def dataset(self):
+        """
+        Returns parent datset
+        """
+        from .dataset import Dataset
+        return Dataset(self.attributes['dataset'])


### PR DESCRIPTION
For carto layers we want to build the query that produces the layer visualisation (that can be seen using `Layer.map()` and then append a subquery.

Note that this inherently will return a subtable of the parent datasets table.

To cover this use-case, this PR also adds the `Layer.dataset()` method so that you can quickly call the parent dataset object and query the full table:

`Layer.dataset().query()`