### PR TITLE
Feat/meta vocab methods

### DIFF
--- a/LMIPy/dataset.py
+++ b/LMIPy/dataset.py
@@ -379,5 +379,37 @@ class Dataset:
                 print(f'Vocabulary {vocab_type} created.')
                 self.attributes = self.get_dataset()
                 return self
+            else:
+                print(f'Failed with error code {r.status_code}')
+                return None
         else:
-            raise ValueError(f'Vocabulary creation requires: app string, name string, and a list of tags.')
+            raise ValueError(f'Vocabulary creation requires: application string, name string, and a list of tags.')
+
+    def add_metadata(self, meta_params=None, token=None):
+        if not token:
+            raise ValueError(f'[token] Resource Watch API token required to create new vocabulary.')
+        info = meta_params.get('info', None)
+        app = meta_params.get('application', None)
+        ds_id = self.id
+        if info and app:
+            payload = { 
+                "info": info,
+                "application": app,
+                "language": meta_params.get('language', 'en')
+            }
+            try:
+                url = f'https://api.resourcewatch.org/v1/dataset/{ds_id}/metadata'
+                headers = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
+                r = requests.post(url, data=json.dumps(payload), headers=headers)
+            except:
+                raise ValueError(f'Vocabulary creation failed.')
+            if r.status_code == 200:
+                print(f'Metadata created.')
+                self.attributes = self.get_dataset()
+                return self
+            else:
+                print(f'Failed with error code {r.status_code}')
+                return None
+        else:
+            raise ValueError(f'Metadata creation requires an info object and application string.')
+

--- a/LMIPy/dataset.py
+++ b/LMIPy/dataset.py
@@ -358,6 +358,13 @@ class Dataset:
         return Dataset(id_hash=recovered_dataset['id'], attributes=recovered_dataset['attributes'])
 
     def add_vocabulary(self, vocab_params=None, token=None):
+        """
+        Create a new vocabulary association to the current dataset.
+
+        A single application string, name string and tags list must be specified within the `vocab_params` dictionary.
+
+        A RW-API token is required.
+        """
         if not token:
             raise ValueError(f'[token] Resource Watch API token required to create new vocabulary.')
         vocab_type = vocab_params.get('name', None)
@@ -386,6 +393,15 @@ class Dataset:
             raise ValueError(f'Vocabulary creation requires: application string, name string, and a list of tags.')
 
     def add_metadata(self, meta_params=None, token=None):
+        """
+        Create a new metadata association to the current dataset.
+
+        A single application string and language string ('en' by default) must be specified within the
+        `meta_params` dictionary, as well as an (optional) info dictionary.
+        Info has a free schema.
+
+        A RW-API token is required.
+        """
         if not token:
             raise ValueError(f'[token] Resource Watch API token required to create new vocabulary.')
         info = meta_params.get('info', None)

--- a/LMIPy/dataset.py
+++ b/LMIPy/dataset.py
@@ -356,3 +356,28 @@ class Dataset:
         except:
             raise ValueError(f'Failed to load backup from f{path}/{self.id}.json')
         return Dataset(id_hash=recovered_dataset['id'], attributes=recovered_dataset['attributes'])
+
+    def add_vocabulary(self, vocab_params=None, token=None):
+        if not token:
+            raise ValueError(f'[token] Resource Watch API token required to create new vocabulary.')
+        vocab_type = vocab_params.get('name', None)
+        vocab_tags = vocab_params.get('tags', None)
+        app = vocab_params.get('application', None)
+        ds_id = self.id
+        if vocab_tags and len(vocab_tags) > 0 and vocab_type and app:
+            payload = { 
+                "tags": vocab_tags,
+                "application": app
+            }
+            try:
+                url = f'https://api.resourcewatch.org/v1/dataset/{ds_id}/vocabulary/{vocab_type}'
+                headers = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
+                r = requests.post(url, data=json.dumps(payload), headers=headers)
+            except:
+                raise ValueError(f'Vocabulary creation failed.')
+            if r.status_code == 200:
+                print(f'Vocabulary {vocab_type} created.')
+                self.attributes = self.get_dataset()
+                return self
+        else:
+            raise ValueError(f'Vocabulary creation requires: app string, name string, and a list of tags.')

--- a/LMIPy/layer.py
+++ b/LMIPy/layer.py
@@ -296,9 +296,9 @@ class Layer:
 
     def clone(self, token=None, env='staging', layer_params={}, target_dataset_id=None):
         """
-        Create a clone of a target Layer (and its parent Dataset) as a new staging or prod Layer.
-        A set of attributes can be specified for the clone Layer.
-        Optionally, you can also select a target Dataset to attach your Layer-Clone to.
+        Create a clone of current Layer (and its parent Dataset) as a new staging or prod Layer.
+        A set of attributes can be specified for the clone Layer using layer_params.
+        Optionally, you can also select a target Dataset to attach your Layer clone to.
         """
         from .dataset import Dataset
         if not token:

--- a/LMIPy/lmipy.py
+++ b/LMIPy/lmipy.py
@@ -26,6 +26,13 @@ class Metadata:
         return f"Metadata {self.id}"
 
     def update(self, update_params=None, token=None):
+        """
+        Update the attributes of a Metadata object providing a RW-API token is supplied.
+
+        A single application string and language string ('en' by default) must be specified within the
+        `update_params` dictionary, as well as an (optional) info dictionary.
+        Info has a free schema.
+        """
         from .dataset import Dataset
         if not token:
             raise ValueError(f'[token] Resource Watch API token required to update metadata.')
@@ -57,6 +64,10 @@ class Metadata:
             raise ValueError(f'Metadata update requires info object and application string.')
             
     def delete(self, token=None):
+        """
+        Delete the current metadata, removing it's association to the parent dataset.
+        A RW-API token is required.
+        """
         if not token:
             raise ValueError(f'[token] Resource Watch API token required to delete vocabulary.')
         lang = self.attributes.get('language', None)
@@ -95,6 +106,11 @@ class Vocabulary:
         return f"Vocabulary {self.id}"
 
     def update(self, update_params=None, token=None):
+        """
+        Update the attributes of a Vocabulary object providing a RW-API token is supplied.
+        
+        A single application string, name string and tags list must be specified within the `update_params` dictionary.
+        """
         from .dataset import Dataset
         if not token:
             raise ValueError(f'[token] Resource Watch API token required to update vocabulary.')
@@ -105,6 +121,10 @@ class Vocabulary:
         return Dataset(ds_id).vocabulary
 
     def delete(self, token=None):
+        """
+        Delete the current vocabulary, removing it's association to the parent dataset.
+        A RW-API token is required.
+        """
         if not token:
             raise ValueError(f'[token] Resource Watch API token required to delete vocabulary.')
         vocab_type = self.attributes.get('name', None)

--- a/LMIPy/lmipy.py
+++ b/LMIPy/lmipy.py
@@ -39,12 +39,14 @@ class Metadata:
                 "language": lang,
                 "info": info,
             }
+            print('payload',payload)
             try:
                 url = f'https://api.resourcewatch.org/v1/dataset/{ds_id}/metadata'
+                print('url',url)
                 headers = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
                 r = requests.patch(url, data=json.dumps(payload), headers=headers)
             except:
-                raise ValueError(f'Vocabulary creation failed.')
+                raise ValueError(f'Metadata update failed.')
             if r.status_code == 200:
                 print(f'Metadata updated.')
                 return Dataset(ds_id).metadata
@@ -59,7 +61,7 @@ class Metadata:
             raise ValueError(f'[token] Resource Watch API token required to delete vocabulary.')
         lang = self.attributes.get('language', None)
         app = self.attributes.get('application', None)
-        ds_id = self.id
+        ds_id = self.attributes.get('dataset', None)
         if lang and app:
             try:
                 url = f'http://api.resourcewatch.org/dataset/{ds_id}/metadata?application={app}&language={lang}'

--- a/LMIPy/lmipy.py
+++ b/LMIPy/lmipy.py
@@ -25,6 +25,51 @@ class Metadata:
     def __str__(self):
         return f"Metadata {self.id}"
 
+    def update(self, update_params=None, token=None):
+        from .dataset import Dataset
+        if not token:
+            raise ValueError(f'[token] Resource Watch API token required to update metadata.')
+        app = self.attributes.get('application', None)
+        lang = update_params.get('language', 'en')
+        info = update_params.get('info', None)
+        ds_id = self.id
+        if info and app:
+            payload = {
+                "application": app,
+                "language": lang,
+                "info": info,
+            }
+            try:
+                url = f'https://api.resourcewatch.org/v1/dataset/{ds_id}/metadata'
+                headers = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
+                r = requests.patch(url, data=json.dumps(payload), headers=headers)
+            except:
+                raise ValueError(f'Vocabulary creation failed.')
+            if r.status_code == 200:
+                print(f'Metadata updated.')
+                return Dataset(ds_id).metadata
+            else:
+                print(f'Failed with error code {r.status_code}')
+                return None
+        else:
+            raise ValueError(f'Metadata update requires info object and application string.')
+            
+    def delete(self, token=None):
+        if not token:
+            raise ValueError(f'[token] Resource Watch API token required to delete vocabulary.')
+        lang = self.attributes.get('language', None)
+        app = self.attributes.get('application', None)
+        ds_id = self.id
+        if lang and app:
+            try:
+                url = f'http://api.resourcewatch.org/dataset/{ds_id}/metadata?application={app}&language={lang}'
+                headers = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json', 'Cache-Control': 'no-cache'}
+                r = requests.delete(url, headers=headers)
+            except:
+                raise ValueError(f'Metdata deletion failed.')
+            if r.status_code == 200:
+                print(f'Metdata deleted.')
+        return None
 
 class Vocabulary:
     """

--- a/LMIPy/lmipy.py
+++ b/LMIPy/lmipy.py
@@ -99,8 +99,8 @@ class Vocabulary:
         update_params['application'] = self.attributes.get('application', None)
         ds_id = self.id
         self.delete(token=token)
-        dataset = Dataset(ds_id).add_vocabulary(vocab_params=update_params, token=token)
-        return dataset.vocabulary
+        Dataset(ds_id).add_vocabulary(vocab_params=update_params, token=token)
+        return Dataset(ds_id).vocabulary
 
     def delete(self, token=None):
         if not token:

--- a/LMIPy/lmipy.py
+++ b/LMIPy/lmipy.py
@@ -32,7 +32,7 @@ class Metadata:
         app = self.attributes.get('application', None)
         lang = update_params.get('language', 'en')
         info = update_params.get('info', None)
-        ds_id = self.id
+        ds_id = self.attributes.get('dataset', None)
         if info and app:
             payload = {
                 "application": app,

--- a/LMIPy/lmipy.py
+++ b/LMIPy/lmipy.py
@@ -1,5 +1,6 @@
 import requests
 import random
+import json
 from .utils import html_box
 
 
@@ -45,3 +46,30 @@ class Vocabulary:
 
     def __str__(self):
         return f"Vocabulary {self.id}"
+
+    def update(self, update_params=None, token=None):
+        from .dataset import Dataset
+        if not token:
+            raise ValueError(f'[token] Resource Watch API token required to update vocabulary.')
+        update_params['application'] = self.attributes.get('application', None)
+        ds_id = self.id
+        self.delete(token=token)
+        dataset = Dataset(ds_id).add_vocabulary(vocab_params=update_params, token=token)
+        return dataset.vocabulary
+
+    def delete(self, token=None):
+        if not token:
+            raise ValueError(f'[token] Resource Watch API token required to delete vocabulary.')
+        vocab_type = self.attributes.get('name', None)
+        app = self.attributes.get('application', None)
+        ds_id = self.id
+        if vocab_type and app:
+            try:
+                url = f'http://api.resourcewatch.org/dataset/{ds_id}/vocabulary/{vocab_type}?app={app}'
+                headers = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json', 'Cache-Control': 'no-cache'}
+                r = requests.delete(url, headers=headers)
+            except:
+                raise ValueError(f'Vocabulary deletion failed.')
+            if r.status_code == 200:
+                print(f'Vocabulary {vocab_type} deleted.')
+        return None

--- a/tests/test_lmipy.py
+++ b/tests/test_lmipy.py
@@ -1,5 +1,5 @@
 import pytest
-from LMIPy import Dataset, Collection, Layer
+from LMIPy import Dataset, Collection, Layer, Metadata, Vocabulary
 
 def test_create_dataset():
     ds = Dataset(id_hash='bb1dced4-3ae8-4908-9f36-6514ae69713f')
@@ -20,3 +20,14 @@ def test_search_collection():
 def test_layer_creation():
     ly = Layer(id_hash='dc6f6dd2-0718-4e41-81d2-109866bb9edd')
     assert ly is not None
+
+def test_access_vocab():
+    ds = Dataset(id_hash='bb1dced4-3ae8-4908-9f36-6514ae69713f')
+    assert type(ds.vocabulary) == list
+    assert len(ds.vocabulary) > 0
+
+def test_access_meta():
+    ds = Dataset(id_hash='bb1dced4-3ae8-4908-9f36-6514ae69713f')
+    assert type(ds.metadata) == list
+    assert len(ds.metadata) > 0
+    


### PR DESCRIPTION
Adds `update`, `delete` methods for the Metadata & Vocabulary classes as well as `add_vocabulary` and `add_metadata` methods to the Dataset class.

Note that currently `patch` requests for Vocabularies are not supported by the api hence the `update` method requiring the deletion and recreation of the vocabulary when 'updating'.