### PR TITLE
Hotfix/clone env

### DIFF
--- a/LMIPy/layer.py
+++ b/LMIPy/layer.py
@@ -333,9 +333,29 @@ class Layer:
             r = requests.post(url, data=json.dumps(payload), headers=headers)
             if r.status_code == 200:
                 target_dataset_id = r.json()['data']['id']
+                clone_dataset = Dataset(target_dataset_id)
+                try:
+                    vocab = target_dataset.vocabulary[0].attributes
+                    vocab_payload = {
+                        'application': vocab['application'],
+                        'name': vocab['name'],
+                        'tags': vocab['tags']
+                    }
+                    clone_dataset.add_vocabulary(vocab_params=vocab_payload, token=token)
+                    meta = target_dataset.metadata[0].attributes
+                    meta_payload = {
+                        'application': meta['application'],
+                        'info': meta['info'],
+                        'language': meta['language']
+                    }
+                    clone_dataset.add_metadata(meta_params=meta_payload, token=token)
+                except:
+                    raise ValueError('Failed to clone Vocabulary and Metadata.')
             else:
                 print(r.status_code)
                 return None
+            
+
         payload = {
             'application': clone_layer_attr['application'],
             'applicationConfig': clone_layer_attr['applicationConfig'],

--- a/LMIPy/layer.py
+++ b/LMIPy/layer.py
@@ -324,7 +324,7 @@ class Layer:
                 'connectorUrl': clone_dataset_attr['connectorUrl'],
                 'tableName': clone_dataset_attr['tableName'],
                 'provider': clone_dataset_attr['provider'],
-                'env': clone_dataset_attr['env'],
+                'env': env,
                 'name': clone_dataset_attr['name']
             }
             print(f'Creating clone dataset')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="LMIPy",
-    version="0.1.11",
+    version="0.1.14",
     author="Vizzuality",
     author_email="benjamin.laken@vizzuality.com",
     description="Interface to data and layers in the Resource Watch API",


### PR DESCRIPTION
Fixes the `.clone()` method to also clone attached Metadata and Vocabs from the cloned layers parent dataset if a target dataset is not defined.

The env param now applies to the cloned dataset too.