### PR TITLE
Retains entities with the same name in collection search.

### DIFF
--- a/LMIPy/collection.py
+++ b/LMIPy/collection.py
@@ -176,7 +176,7 @@ class Collection:
 
     def save(self, path=None):
         """
-        Save all entities in the collection to a loca path.
+        Save all entities in the collection to a local path.
         """
         if not path:
             path = './LMI-BACKUP'

--- a/LMIPy/collection.py
+++ b/LMIPy/collection.py
@@ -175,6 +175,9 @@ class Collection:
         return tmp_sorted
 
     def save(self, path=None):
+        """
+        Save all entities in the collection to a loca path.
+        """
         if not path:
             path = './LMI-BACKUP'
             if not os.path.isdir(path):

--- a/LMIPy/collection.py
+++ b/LMIPy/collection.py
@@ -157,8 +157,14 @@ class Collection:
         tmp_sorted = []
         try:
             d = {}
+            duplicate = {}
             for n, z in enumerate([c['attributes'].get(self.order.lower()) for c in collection_list]):
-                d[z] = collection_list[n]
+                if duplicate.get(z, None):
+                    d[f'{z} {duplicate[z]}'] = collection_list[n]
+                    duplicate[z] += 1
+                else:
+                    d[z] = collection_list[n]
+                    duplicate[z] = 1
             keys = sorted(d, reverse=self.sort.lower() == 'asc')
             for key in keys:
                 tmp_sorted.append(d[key])

--- a/LMIPy/dataset.py
+++ b/LMIPy/dataset.py
@@ -339,7 +339,12 @@ class Dataset:
                     "id": v.id,
                     "type": "vocabulary",
                     "attributes": v.attributes
-                    } for v in self.vocabulary]
+                    } for v in self.vocabulary],
+                'widget': [{
+                    "id": w.id,
+                    "type": "widget",
+                    "attributes": w.attributes
+                    } for w in self.widget]
                 },
         }
         if not os.path.isdir(path):

--- a/LMIPy/utils.py
+++ b/LMIPy/utils.py
@@ -236,19 +236,18 @@ def sldDump(sldObj):
     return sld_str + "+ </ColorMap> + </RasterSymbolizer>"
 
 def sldParse(sld_str):
+    """
+    Builds a dictionary from an SldStyle string.
+    """
     sld_str = sld_str.replace("'", '"')
     values = ['color', 'label', 'quantity', 'opacity']
     items = [el.strip() for el in sld_str.split('+') if 'ColorMapEntry'in el]
-
     sld_items = []
-
     for i in items:
         tmp = {}
         for v in values:
             tmp[v] = find_between(i, f'{v}="', '"')
-
-        sld_items.append(tmp)    
-    
+        sld_items.append(tmp)
     return {
         'type': find_between(sld_str, 'type="', '"'),
         'extended': find_between(sld_str, 'extended="', '"'),

--- a/LMIPy/utils.py
+++ b/LMIPy/utils.py
@@ -212,3 +212,53 @@ def parse_filters(filter_objects):
             print(f'Unable to filter by{error_string[:-1]}.')
         return return_string
     return ''
+
+def sldDump(sldObj):
+    """
+    Creates valid SldStyle string from an object.
+    """
+    sld_type = sldObj.get('type', None)
+    extended = str(sldObj.get('extended', 'false')).lower()
+    items = sldObj.get('items', None)
+    
+    if sld_type not in ["values", "ramp", "intervals"]:
+        print('Unable to create SldStyle. Type must be in "values", "ramp", "intervals".')
+        return None
+    if items:
+        sld_str = f'<RasterSymbolizer> + <ColorMap type="{sld_type}" extended="{extended}"> '
+        for item in items:
+            color = item.get("color", "")
+            quantity = item.get("quantity", "")
+            label = item.get("label", "")
+            opacity = item.get("opacity", "1")
+            
+            sld_str += f'+ <ColorMapEntry color="{color}" label="{label}" quantity="{quantity}" opacity="{opacity}"/> '
+    return sld_str + "+ </ColorMap> + </RasterSymbolizer>"
+
+def sldParse(sld_str):
+    sld_str = sld_str.replace("'", '"')
+    values = ['color', 'label', 'quantity', 'opacity']
+    items = [el.strip() for el in sld_str.split('+') if 'ColorMapEntry'in el]
+
+    sld_items = []
+
+    for i in items:
+        tmp = {}
+        for v in values:
+            tmp[v] = find_between(i, f'{v}="', '"')
+
+        sld_items.append(tmp)    
+    
+    return {
+        'type': find_between(sld_str, 'type="', '"'),
+        'extended': find_between(sld_str, 'extended="', '"'),
+        'items': sld_items
+    }
+
+def find_between(s, first, last):
+    try:
+        start = s.index(first) + len(first)
+        end = s.index(last, start)
+        return s[start:end]
+    except ValueError:
+        return ""

--- a/LMIPy/utils.py
+++ b/LMIPy/utils.py
@@ -239,9 +239,9 @@ def sldParse(sld_str):
     """
     Builds a dictionary from an SldStyle string.
     """
-    sld_str = sld_str.replace("'", '"')
+    sld_str = sld_str.replace("'", '"').replace('\"', '"')
     values = ['color', 'label', 'quantity', 'opacity']
-    items = [el.strip() for el in sld_str.split('+') if 'ColorMapEntry'in el]
+    items = [el.strip() for el in sld_str.split('ColorMapEntry') if '<RasterSymbolizer>' not in el]
     sld_items = []
     for i in items:
         tmp = {}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="LMIPy",
-    version="0.2.5",
+    version="0.2.6",
     author="Vizzuality",
     author_email="benjamin.laken@vizzuality.com",
     description="Interface to data and layers in the Resource Watch API",


### PR DESCRIPTION
Fixes bug with dropping entities with the same name (or same _order_ key) in Collection search.

BONUS 🎉 

Adds helpers for parsing `sldValue` strings into objects and constructing `sldValue` strings into objects for easier updating.

Accessed using `LMIPy.utils.sldParse()` and `LMIPy.utils.sldDump()`