### PR TITLE
Adds direct creation of layer/dataset entities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="LMIPy",
-    version="0.2.5",
+    version="0.2.6",
     author="Vizzuality",
     author_email="benjamin.laken@vizzuality.com",
     description="Interface to data and layers in the Resource Watch API",


### PR DESCRIPTION
When constructing using `lmi.Dataset()` and `lmi.Layer()` you can now specify attributes and a valid api token to post a new layer or dataset directly to the api (so long as the server is _RW_ or _None_)